### PR TITLE
feature/add-sonar-widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,9 @@ A dockerized dashboard for developing dashboard components locally.
 1. Install docker locally
 1. From the root of this repo, run `docker build -t dashboard .`. This will build the docker container.
 1. To start the dashboard, run `docker run -d -p 8080:3030 dashboard`. The dashboard is now available in your web browser via http://localhost:8080.
+
+# How to get the SonarQube widget working
+1. The widget queries a local SonarQube service running on port 9000. Therefore, run `docker run -d --name sonarqube -p 9000:9000 sonarqube` in order to stand up that service. SonarQube is now available in your web browser at http://localhost:9000. Login to the SonarQube using the default username/password combination of admin/admin.
+2. The dashboard still needs to know the network address for this SonarQube instance. Run `docker network inspect bridge`, find the container named sonarqube and note its IPv4Address.
+3. Edit jobs/sonar.rb and change the value for bridge_network_sq_ip to the IPv4Address value from the previous step.
+4. Rebuild and re-run the dashboard container. The widget should now display the "Health" value of "GREEN".

--- a/smashing/dashboards/main.erb
+++ b/smashing/dashboards/main.erb
@@ -5,8 +5,9 @@
       <div data-id="image" data-view="Image" data-title="My Sweet Image" data-image="/logo_aetna.png"></div>
     </li>
 
-    <li data-row="1" data-col="2" data-sizex="1" data-sizey="1">
-      <div data-id="valuation" data-view="Number" data-title="Current Valuation" data-moreinfo="In billions" data-prefix="$"></div>
+    <li data-row="1" data-col="3" data-sizex="1" data-sizey="1">
+     <div data-id="sonar" data-view="List" data-unordered="true" data-title="Sonar Stats" data-moreinfo="values gathered from SQ">
+     </div>
     </li>
 
     <li data-row="1" data-col="4" data-sizex="1" data-sizey="2">

--- a/smashing/jobs/sonar.rb
+++ b/smashing/jobs/sonar.rb
@@ -1,0 +1,31 @@
+require 'net/http'
+require 'json'
+require 'time'
+
+puts 'Initializing sonar widget...'
+STDOUT.flush
+
+bridge_network_sq_ip = '172.17.0.1'
+
+sonar_stat = Hash.new({ value: 0 })
+
+SONAR_URI = URI.parse("http://" + bridge_network_sq_ip + ":9000")
+SONAR_AUTH = {
+'name' => 'admin',
+'password' => 'admin'
+}
+
+SCHEDULER.every '15s', :first_in => 0 do |job|
+  http = Net::HTTP.new(SONAR_URI.host, SONAR_URI.port)
+
+  request = Net::HTTP::Get.new("/api/system/health")
+  if SONAR_AUTH['name']
+      request.basic_auth(SONAR_AUTH['name'], SONAR_AUTH['password'])
+  end
+  response = http.request(request)
+  response_json = JSON.parse(response.body)
+
+  sonar_stat["health"] = { label: "Health", value: response_json["health"] }
+
+  send_event('sonar', { items: sonar_stat.values })
+end


### PR DESCRIPTION
Add basic SonarQube widget job.
Add widget to main dashboard.
Update README with details about SonarQube widget.